### PR TITLE
chore(deps): bump https://github.com/cramte/jx-qs-python.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -1,0 +1,5 @@
+# Dependency Matrix
+
+Dependency | Sources | Version | Mismatched versions
+---------- | ------- | ------- | -------------------
+[cramte/jx-qs-python](https://github.com/cramte/jx-qs-python.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- host: github.com
+  owner: cramte
+  repo: jx-qs-python
+  url: https://github.com/cramte/jx-qs-python.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/cramte-jx-qs-python-sr.yaml
+++ b/repositories/templates/cramte-jx-qs-python-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: cramte
+    provider: github
+    repository: jx-qs-python
+  name: cramte-jx-qs-python
+spec:
+  description: Imported application for cramte/jx-qs-python
+  httpCloneURL: https://github.com/cramte/jx-qs-python.git
+  org: cramte
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-qs-python
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/cramte/jx-qs-python.git


### PR DESCRIPTION
Update [cramte/jx-qs-python](https://github.com/cramte/jx-qs-python.git) 

Command run was `jx create quickstart --git-public=true`